### PR TITLE
chore(frontend): add verify/typecheck scripts and build:ci

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint . --max-warnings=0",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "verify": "npm run lint && npm run typecheck",
+    "build:ci": "next build"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",


### PR DESCRIPTION
What
- Add scripts: lint (eslint CLI), typecheck (tsc --noEmit), verify (lint+typecheck), build:ci (next build).

Why
- Make CI deterministic and avoid Next’s TypeScript dependency check during lint.
- Unblock Vercel build command: npm ci --include=dev && npm run verify && npm run build:ci.

Notes
- Expect new required checks: “Frontend CI / verify” and “Frontend CI / build:ci”.
